### PR TITLE
Add interface option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,10 @@ GLOBAL OPTIONS:
    --server-json value            Use an alternative server list from remote JSON file
    --local-json value             Use an alternative server list from local JSON file,
                                   or read from stdin with "--local-json -".
-   --source SOURCE                SOURCE IP address to bind to
+   --source SOURCE                SOURCE IP address to bind to. Incompatible with --interface.
+   --interface INTERFACE          The name of the network interface to bind to. Example: "enp0s3".
+                                  Not supported on Windows and incompatible with --source.
+                                  Implies --no-icmp.
    --timeout TIMEOUT              HTTP TIMEOUT in seconds. (default: 15)
    --duration value               Upload and download test duration in seconds (default: 15)
    --chunks value                 Chunks to download from server, chunk size depends on server configuration (default: 100)

--- a/defs/options.go
+++ b/defs/options.go
@@ -24,6 +24,7 @@ const (
 	OptionExclude         = "exclude"
 	OptionServerJSON      = "server-json"
 	OptionSource          = "source"
+	OptionInterface       = "interface"
 	OptionTimeout         = "timeout"
 	OptionChunks          = "chunks"
 	OptionUploadSize      = "upload-size"

--- a/main.go
+++ b/main.go
@@ -139,6 +139,10 @@ func main() {
 				Name:  defs.OptionSource,
 				Usage: "`SOURCE` IP address to bind to",
 			},
+			&cli.StringFlag{
+				Name:  defs.OptionInterface,
+				Usage: "network INTERFACE to bind to",
+			},
 			&cli.IntFlag{
 				Name:  defs.OptionTimeout,
 				Usage: "HTTP `TIMEOUT` in seconds.",

--- a/speedtest/helper.go
+++ b/speedtest/helper.go
@@ -28,7 +28,7 @@ const (
 )
 
 // doSpeedTest is where the actual speed test happens
-func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.TelemetryServer, network string, silent bool) error {
+func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.TelemetryServer, network string, silent bool, noICMP bool) error {
 	if serverCount := len(servers); serverCount > 1 {
 		log.Infof("Testing against %d servers", serverCount)
 	}
@@ -70,7 +70,7 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 			}
 
 			// skip ICMP if option given
-			currentServer.NoICMP = c.Bool(defs.OptionNoICMP)
+			currentServer.NoICMP = noICMP
 
 			p, jitter, err := currentServer.ICMPPingAndJitter(pingCount, c.String(defs.OptionSource), network)
 			if err != nil {

--- a/speedtest/util_linux.go
+++ b/speedtest/util_linux.go
@@ -1,0 +1,32 @@
+package speedtest
+
+import (
+	"net"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func newDialerInterfaceBound(iface string) (dialer *net.Dialer, err error) {
+	// In linux there is the socket option SO_BINDTODEVICE.
+	// Therefore we can really bind the socket to the device instead of binding to the address that
+	// would be affected by the default routes.
+	control := func(network, address string, c syscall.RawConn) error {
+		var errSock error
+		err := c.Control((func(fd uintptr) {
+			errSock = unix.BindToDevice(int(fd), iface)
+		}))
+		if err != nil {
+			return err
+		}
+		return errSock
+	}
+
+	dialer = &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   control,
+	}
+	return dialer, nil
+}

--- a/speedtest/util_windows.go
+++ b/speedtest/util_windows.go
@@ -1,0 +1,10 @@
+package speedtest
+
+import (
+	"fmt"
+	"net"
+)
+
+func newDialerInterfaceBound(iface string) (dialer *net.Dialer, err error) {
+	return nil, fmt.Errorf("cannot bound to interface on Windows")
+}


### PR DESCRIPTION
This is a mirror of librespeed/speedtest-cli#65. That PR adds support for specifying an interface for the speedtest to bind to - which is extremely useful.

Unfortunately upstream seems to be very stale and hasn't reviewed or accepted this PR (or really any other PRs in quite a while). So, I'm pulling it in directly to our fork to try it out.